### PR TITLE
Fix class_attribute behaviour

### DIFF
--- a/lib/simple_states.rb
+++ b/lib/simple_states.rb
@@ -42,7 +42,7 @@ module SimpleStates
 
     def event(name, options = {})
       add_states(options[:from], options[:to])
-      self.events << Event.new(name, options)
+      self.events += [Event.new(name, options)]
     end
   end
 
@@ -68,3 +68,4 @@ module SimpleStates
     method.to_s =~ /(was_|^)(#{self.class.states.join('|')})\?$/ ? send(:"#{$1}state?", $2, *args) : super
   end
 end
+


### PR DESCRIPTION
Don't change `self.events` in place. This change is all that's needed to make `class_attribute` behave correctly. See this [Stack Overflow question](http://stackoverflow.com/questions/6617769/how-do-i-replicate-class-inheritable-accessors-behavior-in-rails-3-1) for info.
