### PR TITLE
allow passing an array as a :from option

### DIFF
--- a/lib/simple_states.rb
+++ b/lib/simple_states.rb
@@ -42,7 +42,7 @@ module SimpleStates
     end
 
     def event(name, options = {})
-      add_states(options[:from], options[:to])
+      add_states(*options[:from], options[:to])
       self.events += [Event.new(name, options)]
     end
   end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -16,10 +16,23 @@ class AssertionsTest < Test::Unit::TestCase
     end
   end
 
-  test "does not raise an exception if an event is received when the object is in one of the expected states (multiple :from states)" do
+  test "does not raise an exception if an event is received when the object is in one of the expected states (multiple :from states using :all)" do
     klass = create_class do
       event :error, :from => :started, :to => :errored
       event :all, :from => :warning
+    end
+
+    object = klass.new
+    object.state = :warning
+
+    assert_nothing_raised(SimpleStates::TransitionException) do
+      object.error
+    end
+  end
+
+  test "does not raise an exception if an event is received when the object is in one of the expected states (multiple :from states using from: [])" do
+    klass = create_class do
+      event :error, :from => [:started, :warning], :to => :errored
     end
 
     object = klass.new
@@ -43,10 +56,23 @@ class AssertionsTest < Test::Unit::TestCase
     end
   end
 
-  test "raises an exception if an event is received when the object is not in any of the expected states (multiple :from states)" do
+  test "raises an exception if an event is received when the object is not in any of the expected states (multiple :from states using :all)" do
     klass = create_class do
       event :error, :from => :started, :to => :errored
       event :all, :from => :warning
+    end
+
+    object = klass.new
+    object.state = :initialized
+
+    assert_raises(SimpleStates::TransitionException) do
+      object.error
+    end
+  end
+
+  test "raises an exception if an event is received when the object is not in any of the expected states (multiple :from states using from: [])" do
+    klass = create_class do
+      event :error, :from => [:started, :warning], :to => :errored
     end
 
     object = klass.new


### PR DESCRIPTION
If i'm reading the README correctly, I think it says you're supposed to be able to do this, but I was getting
`NoMethodError: undefined method`to_sym' for [:started, :warning]:Array`

when I tried to. 

The `Events` class seems like it was ready to handle this as well, so maybe I'm missing something, but if not, this tiny change does away with that `NoMethodError`
