### PR TITLE
Ensure that `can_transition?` checks against symbolized state

### DIFF
--- a/lib/simple_states/event.rb
+++ b/lib/simple_states/event.rb
@@ -48,7 +48,7 @@ module SimpleStates
       end
 
       def can_transition?(object)
-        !options.from || object.state && Array(options.from).include?(object.state.to_sym)
+        !options.from || object.state && Array(options.from).include?(object.state.try(:to_sym)
       end
 
       def run_callbacks(object, type, args)


### PR DESCRIPTION
Works fine for me after the change
