### PR TITLE
converted ActiveSupport's magic into explicit Ruby code

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'bundler/setup'
 require 'test/unit'
 require 'test_declarative'
-require 'mocha'
+require 'mocha/setup'
 
 begin
   require 'ruby-debug'


### PR DESCRIPTION
This commit doesn't change any behaviors, I just changed the code to not rely on `ActiveSupport`'s magic to instead explicitly use Ruby code.

There is still a dependency on AS due to the couple of places where `try` is being used (we could remove the calls, if you wish to not depend on AS).
