### PR TITLE
Reduce the number of jobs run in each Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - ruby-head


### PR DESCRIPTION
There's no need to have two different JRUBY_OPTS for _every_ single
ruby, only JRuby.

Not completely sure if this is valid syntax, let's see what happens to the build.
