### PR TITLE
return the state of the object after calling a transition/event method

### DIFF
--- a/lib/simple_states/states.rb
+++ b/lib/simple_states/states.rb
@@ -33,6 +33,7 @@ module SimpleStates
           event.send(:call, self, *args) do
             super(*args) if self.class.method_defined?(event.name)
           end
+          state
         end
 
         define_method(:"#{event.name}!") do |*args|

--- a/test/states_test.rb
+++ b/test/states_test.rb
@@ -24,6 +24,11 @@ class StatesTest < Test::Unit::TestCase
     assert object.state?(:started)
   end
 
+  test "returns the state when calling a transition" do
+    object = create_class { states :started; event :start }.new
+    assert_equal :started, object.start
+  end
+
   test "raises TransitionException if no :to option is given and the state can not be derived from the states list" do
     object = create_class { event :start }.new
     assert_raises(SimpleStates::TransitionException) { object.start }


### PR DESCRIPTION
when calling a banged version of the method, the result of the save will be returned instead.
