### PR TITLE
Add trigger method

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,14 @@ foo.finished_at      # Time.now
 foo.was_created?     # true
 foo.was_started?     # true
 ```
+
+You can also use the `trigger` method:
+
+```ruby
+foo = Foo.new
+
+foo.trigger(:finish)
+
+foo.state            # :finished
+foo.finished?        # true
+```

--- a/lib/simple_states.rb
+++ b/lib/simple_states.rb
@@ -74,5 +74,10 @@ module SimpleStates
   def method_missing(method, *args, &block)
     method.to_s =~ /(was_|^)(#{self.class.states.join('|')})\?$/ ? send(:"#{$1}state?", $2, *args) : super
   end
-end
 
+  def trigger(name)
+    found_event = self.class.events.find { |event| event.name == name }
+    return send(found_event.name) unless found_event.nil?
+    raise TransitionException, "cannot trigger event #{name}, event does not exist"
+  end
+end

--- a/lib/simple_states/version.rb
+++ b/lib/simple_states/version.rb
@@ -1,3 +1,3 @@
 module SimpleStates
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/simple_states.gemspec
+++ b/simple_states.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'hashr', '~> 0.0.10'
 
   s.add_development_dependency 'rake', '~> 0.9.2'
+  s.add_development_dependency 'test-unit'
   s.add_development_dependency 'test_declarative'
   s.add_development_dependency 'mocha'
 end

--- a/test/states_test.rb
+++ b/test/states_test.rb
@@ -38,6 +38,22 @@ class StatesTest < Test::Unit::TestCase
     assert_nothing_raised(SimpleStates::TransitionException) { object.start }
   end
 
+  test "triggers an event" do
+    klass = create_class { states :created, :started; event :start, :from => :created, :to => :started }
+    object = klass.new
+
+    assert object.state?(:created)
+
+    object.trigger(:start)
+
+    assert object.state?(:started)
+  end
+
+  test "raises TransitionException if event does not exist" do
+    object = create_class { event :finish }.new
+    assert_raises(SimpleStates::TransitionException) { object.trigger(:start) }
+  end
+
   test "state? returns true if the object has the given state" do
     object = create_class { event :start, :from => :created, :to => :started }.new
 


### PR DESCRIPTION
This adds a `trigger` method. This is helpful when you want to call an event
using a data structure rather than method calls.

Currently I implement this (I would like to remove it):

```ruby
module StateTransition
  def transition(state)
    if self.class.events.map(&:name).include?(state.to_sym)
      send(state.to_sym)
    else
      raise SimpleStates::TransitionException, "invalid event #{state}"
    end
  end
end
```