### PR TITLE
[WIP] Check timestamps before overwriting them 

### DIFF
--- a/lib/simple_states/event.rb
+++ b/lib/simple_states/event.rb
@@ -36,7 +36,11 @@ module SimpleStates
       end
 
       def set_attr(obj, key, value)
-        obj.send(:"#{key}=", value) if obj.respond_to?(:"#{key}=")
+        obj.send(:"#{key}=", value) if obj.respond_to?(:"#{key}=") and not has_timestamp?(obj, key)
+      end
+
+      def has_timestamp?(obj, key)
+        key.to_s.end_with?('_at') && obj.respond_to?(key) && obj.send(key)
       end
 
       def ordered?(obj, data)

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -34,8 +34,28 @@ describe SimpleStates, 'event' do
     end
 
     describe 'when a timestamp is passed' do
-      let(:attrs) { { started_at: now - 60 } }
+      let(:attrs) { { started_at: now - 60, state: "started" } }
       it { expect { obj.start(attrs) }.to change { obj.started_at }.to(attrs[:started_at]) }
+    end
+  end
+
+  describe 'ignores timestamp' do
+    describe 'when started_at had been set earlier' do
+      let(:attrs) { { started_at: now - 60, finished_at: now - 50, state: "passed" } }
+      let(:early) { now - 55 }
+      before      { obj.started_at = early }
+      before      { obj.finish(attrs) }
+      it { expect(obj.started_at).to eq early }
+      it { expect(obj.finished_at).to eq attrs[:finished_at] }
+    end
+
+    describe 'when finished_at had been set earlier' do
+      let(:attrs) { { started_at: now - 60, finished_at: now - 50, state: "passed" } }
+      let(:early) { now - 45 }
+      before      { obj.finished_at = early }
+      before      { obj.finish(attrs) }
+      it { expect(obj.started_at).to eq attrs[:started_at] }
+      it { expect(obj.finished_at).to eq early }
     end
   end
 


### PR DESCRIPTION
Some of timestamps (started_at) are overwritten during the finish state. Mainly because a new timestamp is passed on the attributes. 
We should validate first that we really want to accept these new timestamp by comparing the key name  to the `target_state`  or checking if the current key is for the `finished_at` attribute