### PR TITLE
Use new respond_to? method signature

### DIFF
--- a/lib/simple_states.rb
+++ b/lib/simple_states.rb
@@ -57,7 +57,7 @@ module SimpleStates
     self.class::States.events.map { |_, event| event.reset(self) }
   end
 
-  def respond_to?(name)
+  def respond_to?(name, include_all = false)
     state = name.to_s[0..-2].to_sym
     name.to_s[-1] == '?' && self.class.state?(state) || super
   end


### PR DESCRIPTION
This removes a deprecation warning on Ruby 2.4.1.